### PR TITLE
Update statemanager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.gb
 *.gb.*
 *.state
+*.pkl
 
 # env
 .env

--- a/src/bot/slack_bot.py
+++ b/src/bot/slack_bot.py
@@ -17,7 +17,7 @@ if not SLACK_TOKEN or not SLACK_XAPP or not VALID_REACTIONS:
 
 app = App(token=SLACK_TOKEN)
 
-TIMER_DURATION = 30
+TIMER_DURATION = 15
 timer_active = False
 
 

--- a/src/bot/slack_bot.py
+++ b/src/bot/slack_bot.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from bot.slack_event_handlers import handle_input, calculate_reactions
+from state.state_manager import state_manager
 
 load_dotenv()
 
@@ -29,6 +30,9 @@ def start_slack_bot():
 @app.event("reaction_added")
 def handle_reaction_added(event, say, client):
     global timer_active
+
+    if state_manager.get_last_message() and event["item"]["ts"] != state_manager.get_last_message()["ts"]:
+        return
 
     reaction = event.get("reaction")
     if reaction not in json.loads(VALID_REACTIONS):

--- a/src/state/state_manager.py
+++ b/src/state/state_manager.py
@@ -1,3 +1,7 @@
+import os
+import pickle
+
+
 class StateManager:
     def __init__(self):
         self.last_message = None
@@ -9,4 +13,20 @@ class StateManager:
         return self.last_message
 
 
-state_manager = StateManager()
+def save_state(manager, filename='data/state_manager.pkl'):
+    with open(filename, 'wb') as file:
+        pickle.dump(manager, file)
+
+
+def load_state(filename='data/state_manager.pkl'):
+    if os.path.exists(filename):
+        with open(filename, 'rb') as file:
+            return pickle.load(file)
+    else:
+        manager = StateManager()
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        save_state(manager, filename)
+        return manager
+
+
+state_manager = load_state()


### PR DESCRIPTION
# Make fixes to statemanager
- Statemanager now serialises to a `.pkl` file at the end of each cycle. This file is loaded when the project is run, creating a persistent state between runs
- If the `.pkl` file doesn't exist, a new one is made, and the state gets set to the first message reacted to
  - In practice this won't be an issue, the `.pkl` file will only not exist on the first ever run, after that it will always exist unless manually deleted
- Reacts now only trigger a timer if they match the timestamp of the correct message
  - Again this won't be the case on the first ever run, and will allow itself to run in order to generate a first message
- Refactors handle_input code to be a little easier to read

## Gitignore change
- Adds `.pkl` files to gitignore

## Var changes
- Updates timer from 30 seconds to 15