### PR TITLE
Add 112 space offset

### DIFF
--- a/src/integration/byte_mappings.py
+++ b/src/integration/byte_mappings.py
@@ -370,7 +370,7 @@ GEN_1_TMS = [
 ]
 
 # Create the offset between TM's and Non-TM's
-GEN_1_ITEMS = GEN_1_NORMAL_ITEMS + [None]*112 + GEN_1_TMS
+GEN_1_ITEMS = GEN_1_NORMAL_ITEMS + [None] * 112 + GEN_1_TMS
 
 GEN_1_MOVES = [
     "",  # Index 0 is no move learnt

--- a/src/integration/byte_mappings.py
+++ b/src/integration/byte_mappings.py
@@ -219,7 +219,7 @@ GEN_1_SPECIES = [
     "Victreebel",
 ]
 
-GEN_1_ITEMS = [
+GEN_1_NORMAL_ITEMS = [
     "",
     "Master Ball",
     "Ultra Ball",
@@ -304,6 +304,9 @@ GEN_1_ITEMS = [
     "Max Ether",
     "Elixer",
     "Max Elixer",
+]
+
+GEN_1_TMS = [
     "HM01",
     "HM02",
     "HM03",
@@ -365,6 +368,9 @@ GEN_1_ITEMS = [
     "TM54",
     "TM55",
 ]
+
+# Create the offset between TM's and Non-TM's
+GEN_1_ITEMS = GEN_1_NORMAL_ITEMS + [None]*112 + GEN_1_TMS
 
 GEN_1_MOVES = [
     "",  # Index 0 is no move learnt


### PR DESCRIPTION
# Fix inventory bug caused by hex offset
- Previously getting a TM would cause an OOB error in the Byte mapping array for the inventory
- This fixes it so that the 112 space offset in the memory values is adjusted for
  - Not the most elegant solutions, just loads 112 blank values in to the byte mapping array