### PR TITLE
Add manifest to version control

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,25 +61,11 @@ $ poetry run lint
 
 ## Slack App
 SlackPlaysPokémon is a Python Bolt app.
-Create a Slack app with the appropriate read/write permissions and socket mode enabled, then add the `xoxb` and `xapp` tokens to the appropriate environment variables in the `.env` file.
+Create a Slack app using the App Manifest found in `app-manifest.json`.
 
-#### Oauth permissions required:
-- reactions:read
-- reactions:write
-- chat:write
-- files:write
-- app_mentions:read
-- channels:read
-- canvases:write
-- groups:read
-- im:read
-- mpim:read
+This manifest can be customised as necesarry, but ensure you don't change any required permissions, the manifest provides the minimum permissions required to run.
 
-#### Socket mode event subscriptions required:
-- app_mention
-- reaction_added
-
-## Slack server
+## Slack instance
 This currently works out-of-the-box for the most part, however a few changes may need to be made to allow the bot to function properly.
 
 - A custom react named `:start:`

--- a/app-manifest.json
+++ b/app-manifest.json
@@ -1,0 +1,42 @@
+{
+    "display_information": {
+        "name": "SlackPlaysPokémon",
+        "description": "Playing Pokémon collaboratively",
+        "background_color": "#ff00ff"
+    },
+    "features": {
+        "bot_user": {
+            "display_name": "SlackPlaysPokemon",
+            "always_online": true
+        }
+    },
+    "oauth_config": {
+        "scopes": {
+            "bot": [
+                "app_mentions:read",
+                "chat:write",
+                "files:write",
+                "reactions:read",
+                "reactions:write",
+                "channels:read",
+                "groups:read",
+                "mpim:read",
+                "im:read"
+            ]
+        }
+    },
+    "settings": {
+        "event_subscriptions": {
+            "bot_events": [
+                "app_mention",
+                "reaction_added"
+            ]
+        },
+        "interactivity": {
+            "is_enabled": true
+        },
+        "org_deploy_enabled": false,
+        "socket_mode_enabled": true,
+        "token_rotation_enabled": false
+    }
+}


### PR DESCRIPTION
Spinning up new Slack apps is clunky, and can get out of sync between releases. Adding the manifest to version control mitigates this, allowing devs to ensure their slack app is up to date with the most recent app requirements.